### PR TITLE
fix: await result of axios.get

### DIFF
--- a/lib/project-manager.js
+++ b/lib/project-manager.js
@@ -68,11 +68,14 @@ ProjectManager.prototype.prepareProject = async function (options) {
 	switch (this.projectType) {
 		case 'app':
 			await this.prepareAppProject();
+			break;
 		case 'module':
 			await this.prepareModuleProject();
+			break;
 		case 'standalone':
 		default:
 			await this.prepareStandaloneRunner();
+			break;
 	}
 
 	await this.downloadAndInstallSocketIoModule();
@@ -228,7 +231,7 @@ ProjectManager.prototype.prepareModuleProject = async function () {
 
 ProjectManager.prototype.prepareStandaloneRunner = async function () {
 	this.logger.debug('Standalone project detected, preparing ...');
-	// TODO: Call this.createKarmaRunnerProject()? Only differnece is additional -u localhost args
+	// TODO: Call this.createKarmaRunnerProject()? Only difference is additional -u localhost args
 	const projectName = 'karma-runner';
 	const args = [
 		'create',

--- a/lib/project-manager.js
+++ b/lib/project-manager.js
@@ -378,7 +378,7 @@ ProjectManager.prototype.getDownloadPath = function (socketIoModule) {
  */
 ProjectManager.prototype.downloadModule = async function (moduleInfo, dest) {
 	await fs.ensureDir(path.dirname(dest));
-	const response = axios.get(moduleInfo.url, { responseType: 'stream' });
+	const response = await axios.get(moduleInfo.url, { responseType: 'stream' });
 	const moduleArchivePath = await pipe(response.data, dest);
 
 	const fileHash = await generateSha1(moduleArchivePath);


### PR DESCRIPTION
This is hopefully a fix for what I broke in #23 

Tested locally by using `npm link` and `npm link karma-titanium-launcher` in a module project that was complaining before this PR.
