### PR TITLE
feat: emit 'prepared' event after project preparation so custom plugins can hook to modify pre-build

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,6 @@ const ProjectManager = require('./lib/project-manager');
 const TitaniumLauncher = require('./lib/titanium-launcher');
 
 module.exports = {
-    'projectManager': ['type', ProjectManager],
-    'launcher:Titanium': ['type', TitaniumLauncher]
+	projectManager: [ 'type', ProjectManager ],
+	'launcher:Titanium': [ 'type', TitaniumLauncher ]
 };

--- a/lib/project-manager.js
+++ b/lib/project-manager.js
@@ -1,11 +1,12 @@
 'use strict';
 
+const EventEmitter = require('events');
 const axios = require('axios');
 // eslint-disable-next-line security/detect-child-process
 const { spawn } = require('child_process');
 const crypto = require('crypto');
-const promisify = require('util').promisify;
-const extract = promisify(require('extract-zip'));
+const util = require('util');
+const extract = util.promisify(require('extract-zip'));
 const fs = require('fs-extra');
 const path = require('path');
 const TiAppXml = require('node-titanium-sdk').tiappxml;
@@ -22,7 +23,7 @@ const socketIoModules = {
 	}
 };
 
-// TODO: Move to class syntax?
+// TODO: Move to class syntax? seems to break karma if we do for now...
 /**
  * @class ProjectManager
  * @property {string} tiBinaryPath path to titanium binary
@@ -45,6 +46,8 @@ function ProjectManager(logger) {
 	this.createdFiles = [];
 	this.dataDirectoryPath = path.join(__dirname, '..', 'data');
 }
+
+util.inherits(ProjectManager, EventEmitter);
 
 /**
  * @param {object} options options used in setup
@@ -83,6 +86,7 @@ ProjectManager.prototype.prepareProject = async function (options) {
 	if (this.projectType === 'app') {
 		this.projectPrepared = true;
 	}
+	this.emit('prepared');
 };
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-titanium-launcher",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-titanium-launcher",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "description": "A Karma plugin. Launcher for Axway Titanium.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This makes the `ProjectManager` extend from `EventEmitter` and emits a `'prepared'` event after preparing the project (but before building it). This allows custom karma plugins/frameworks the opportunity to hook an event listener for `'prepared'` to modify the project post-create but pre-build (to edit the tiapp.xml or inject files into the project, etc).

I tested this with ti.facebook to inject the facebook app id into a resource strings.xml file as well as to modify the tiapp.xml to modify the android manifest xml contents used for the app.

I imagine this mechanism would benefit from emitting other events as well, just wasn't sure what other ones we may want.