### PR TITLE
feat: add command output debug logs

### DIFF
--- a/lib/titanium-launcher.js
+++ b/lib/titanium-launcher.js
@@ -43,7 +43,18 @@ function TitaniumLauncher(baseBrowserDecorator, projectManager, loggerFactory, c
 				'--no-progress-bars'
 			);
 			this._execCommand(this._getCommand(), commandArgs.concat(flags));
-		}, err => {
+
+			if (config.logLevel === config.LOG_DEBUG) {
+				this._process.stdout.on('data', data => {
+					logger.debug(data.toString());
+				});
+				this._process.stderr.on('data', data => {
+					logger.debug(data.toString());
+				});
+			}
+
+			return;
+		}).catch(err => {
 			logger.error(`Failed to prepare project.\n  ${err}`);
 			logger.debug(err.stack);
 			this._done('failure');


### PR DESCRIPTION
This will print output of the `ti build` command of the test runner if log level is set to debug. Allows for easier debugging of JS errors while bootstrapping the Karma environment, i.e. loading the test framework or assertion libraries.