### PR TITLE
fix: force reinstall of sdk if no global modules folder

### DIFF
--- a/lib/project-manager.js
+++ b/lib/project-manager.js
@@ -113,6 +113,13 @@ ProjectManager.prototype.ensureSdkIsInstalled = async function ensureSdkIsInstal
 	}
 	if (sdkList.installed[this.options.sdkVersion]) {
 		this.activeSDK = sdkList.activeSDK; // record the active SDK!
+
+		// If the install looks "bad" (i.e. no global modules), force a re-install
+		if (!await fs.exists(path.join(sdkList.defaultInstallLocation, 'modules'))) {
+			this.logger.debug(`Configured SDK version ${this.options.sdkVersion} is installed, but there are no global modules. Forcing re-install ...`);
+			return this.executeCommand('titanium', [ 'sdk', 'install', this.options.sdkVersion, '--force' ]);
+		}
+
 		this.logger.debug(`Configured SDK version ${this.options.sdkVersion} is installed.`);
 		return;
 	}


### PR DESCRIPTION
This is very unlikely in most cases, but is a common edge case on our own Jenkins build setup. We often wipe the global modules folder after test suites/builds to avoid leaving behind a potentially incompatible or broken module that may get picked up by subsequent builds (particularly since our tiapp.xml tends to just list modules by id with no version so it will use the latest available!)

Again, having no global modules does not matter for many builds but will mysteriously fail on native modules builds that require other modules (i.e. ti.map requires ti.playservices) - or for apps that require modules assumed to be installed globally.

This does a simple sanity check to see if the modules folder exists. If not, it forces a re-install of the target SDK.