### PR TITLE
impr: redirect underlying titanium logs to proper level

### DIFF
--- a/lib/titanium-launcher.js
+++ b/lib/titanium-launcher.js
@@ -6,6 +6,26 @@ function resolveBinaryPath(command) {
 	return which.sync(command, { nothrow: true });
 }
 
+/**
+ * Redirects logs from underlying process to our logger
+ * @param {object} logger logger to redirect to
+ * @param {Buffer|String} data process output/data
+ */
+function redirectLog(logger, data) {
+	const raw = data.toString().trimEnd();
+	const lines = raw.split(/\r?\n/);
+	lines.forEach(l => {
+		// Sniff the log levels and redirect to appropriate levels here
+		const m = l.match(/^\s*\[(ERROR|INFO|DEBUG|WARN|TRACE)\]\s+(.+)$/);
+		if (m) {
+			const level = m[1].toLowerCase();
+			logger[level](m[2]);
+		} else {
+			logger.debug(l); // should we trace by default?
+		}
+	});
+}
+
 function TitaniumLauncher(baseBrowserDecorator, projectManager, loggerFactory, config, args) {
 	baseBrowserDecorator(this);
 
@@ -40,12 +60,8 @@ function TitaniumLauncher(baseBrowserDecorator, projectManager, loggerFactory, c
 			this._execCommand(this._getCommand(), commandArgs.concat(flags));
 
 			if (config.logLevel === config.LOG_DEBUG) {
-				this._process.stdout.on('data', data => {
-					logger.debug(data.toString());
-				});
-				this._process.stderr.on('data', data => {
-					logger.debug(data.toString());
-				});
+				this._process.stdout.on('data', data => redirectLog(logger, data));
+				this._process.stderr.on('data', data => redirectLog(logger, data));
 			}
 
 			return;


### PR DESCRIPTION
This takes all logs coming from the test app build/run process and tries to sniff the output level and redirect to the wrapping logger at the same level. It also happens to "clean up" extra newlines. I did not remove the guard for DEBUg level to hook up the redirect logs. That probably should away as a result of this and just let the logger do whatever filtering it needs to?